### PR TITLE
Fix postinstall #9

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "configure": "node-gyp configure",
     "build": "node-gyp configure build --jobs max",
-    "postinstall": "install_name_tool -change @rpath/libDynamsoftBarcodeReader.dylib @loader_path/libDynamsoftBarcodeReader.dylib build/Release/dbr.node",
+    "postinstall": "node ./scripts/postinstall.js",
     "clean": "node-gyp clean"
   },
   "gypfile": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barcode4nodejs",
-  "version": "9.6.30",
+  "version": "9.6.31",
   "description": "Node.js bindings to Dynamsoft Barcode Reader C/C++ SDK.",
   "keywords": [
     "barcode",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,22 @@
+var exec = require('child_process').exec;
+var os = require('os');
+
+function puts(error, stdout, stderr) { console.error(error) }
+
+const commands_linux = []
+
+const commands_darwin = [
+    "install_name_tool -change @rpath/libDynamsoftBarcodeReader.dylib @loader_path/libDynamsoftBarcodeReader.dylib build/Release/dbr.node"
+]
+
+const commands_windows = []
+
+// Run command depending on the OS
+if (os.type() === 'Linux') {
+    if(commands_linux.length > 0) exec(commands_linux.join('&&'), puts);
+} else if (os.type() === 'Darwin') {
+    if(commands_darwin.length > 0) exec(commands_darwin.join('&&'), puts);
+} else if (os.type() === 'Windows_NT') {
+    if(commands_windows.length > 0) exec(commands_windows.join('&&'), puts);
+}
+


### PR DESCRIPTION
This pull request fixes the changes made with #9 , as the change that was done with version [v9.6.30](https://github.com/yushulx/nodejs-barcode/commit/a83712393304878513d5c61d478f4c73a60224da)

The error that would appear on non-darwin machines would be the following:

```
coder@cs-57fe3519-fa00-4cfb-8300-824f0bb9e294-7b7f6c6955-p29qx:~/project$ npm i
npm ERR! code 127
npm ERR! path /home/coder/project/node_modules/barcode4nodejs
npm ERR! command failed
npm ERR! command sh -c install_name_tool -change @rpath/libDynamsoftBarcodeReader.dylib @loader_path/libDynamsoftBarcodeReader.dylib build/Release/dbr.node
npm ERR! sh: 1: install_name_tool: not found

npm ERR! A complete log of this run can be found in: /home/coder/.npm/_logs/2024-01-04T13_31_35_440Z-debug-0.log
```